### PR TITLE
fix: empty commit to test out changes to release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-texttospeech'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-texttospeech:2.4.2'
+implementation 'com.google.cloud:google-cloud-texttospeech:2.4.4'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-texttospeech" % "2.4.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-texttospeech" % "2.4.4"
 ```
 
 ## Authentication


### PR DESCRIPTION
An empty commit to kick off a new release. The new release will be used to check if the changes in https://github.com/googleapis/java-texttospeech/pull/743 are working fine. 