### PR TITLE
chore: fix requirements file path in release scripts

### DIFF
--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -28,7 +28,8 @@ fi
 pushd $(dirname "$0")/../../
 
 # install docuploader package
-python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
+python3 -m pip install --require-hashes -r $requirementsFile
 
 # compile all packages
 mvn clean install -B -q -DskipTests=true

--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -28,7 +28,8 @@ fi
 pushd $(dirname "$0")/../../
 
 # install docuploader package
-python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
+python3 -m pip install --require-hashes -r $requirementsFile
 
 # compile all packages
 mvn clean install -B -q -DskipTests=true

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -16,7 +16,8 @@
 set -eo pipefail
 
 # Start the releasetool reporter
-python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
+python3 -m pip install --require-hashes -r $requirementsFile
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 
 source $(dirname "$0")/common.sh


### PR DESCRIPTION
Follow-up to https://github.com/googleapis/java-texttospeech/pull/743. Fixes the following failure in the release job:

```
Could not open requirements file: [Errno 2] No such file or directory: '.kokoro/requirements.txt
```

Can confirm that these changes work locally.
